### PR TITLE
✨ Feat: 어빌리티 정보 구현(RD-41)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -85,10 +85,9 @@ model Ability {
   id           Int       @id @default(autoincrement())
   characterId  Int
   character    Character @relation(fields: [characterId], references: [id])
-  abilityGrade String?
+  abilityGrade String
   abilityNo    Int?
   abilityValue String?
-  remainFame   Int?
   presetNo     Int?
   active       Boolean?
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -85,11 +85,12 @@ model Ability {
   id           Int       @id @default(autoincrement())
   characterId  Int
   character    Character @relation(fields: [characterId], references: [id])
-  abilityGrade String
-  abilityNo    Int
-  abilityValue String
-  remainFame   Int
-  presetNo     Int
+  abilityGrade String?
+  abilityNo    Int?
+  abilityValue String?
+  remainFame   Int?
+  presetNo     Int?
+  active       Boolean?
 }
 
 model Equipment {

--- a/src/api/dto/character-ability.dto.ts
+++ b/src/api/dto/character-ability.dto.ts
@@ -1,3 +1,4 @@
+import { Optional } from '@nestjs/common';
 import { Expose } from 'class-transformer';
 import { IsBoolean, IsNumber, IsString } from 'class-validator';
 
@@ -8,6 +9,7 @@ export class CharacterAbilityDTO {
 
   @Expose()
   @IsNumber()
+  @Optional()
   abilityNo: number;
 
   @Expose()
@@ -16,13 +18,10 @@ export class CharacterAbilityDTO {
 
   @Expose()
   @IsNumber()
-  remainFame: number;
-
-  @Expose()
-  @IsNumber()
   presetNo: number;
 
   @Expose()
   @IsBoolean()
+  @Optional()
   active: boolean;
 }

--- a/src/api/dto/character-ability.dto.ts
+++ b/src/api/dto/character-ability.dto.ts
@@ -1,0 +1,28 @@
+import { Expose } from 'class-transformer';
+import { IsBoolean, IsNumber, IsString } from 'class-validator';
+
+export class CharacterAbilityDTO {
+  @Expose()
+  @IsString()
+  abilityGrade: string;
+
+  @Expose()
+  @IsNumber()
+  abilityNo: number;
+
+  @Expose()
+  @IsString()
+  abilityValue: string;
+
+  @Expose()
+  @IsNumber()
+  remainFame: number;
+
+  @Expose()
+  @IsNumber()
+  presetNo: number;
+
+  @Expose()
+  @IsBoolean()
+  active: boolean;
+}

--- a/src/api/dto/character.dto.ts
+++ b/src/api/dto/character.dto.ts
@@ -3,6 +3,7 @@ import { IsBoolean, IsDate, IsInt, IsNumber, IsString, IsUrl, ValidateNested } f
 import { CharacterStatDTO } from './character-stat.dto';
 import { CharacterHyperStatDTO } from './character-hyper-stat.dto';
 import { CharacterPropensityDTO } from './character-propensity.dto';
+import { CharacterAbilityDTO } from './character-ability.dto';
 
 export class CharacterDTO {
   constructor(partial: Partial<CharacterDTO>) {
@@ -84,4 +85,9 @@ export class CharacterDTO {
   @ValidateNested({ each: true })
   @Type(() => CharacterPropensityDTO)
   propensity: CharacterPropensityDTO;
+
+  @Expose()
+  @ValidateNested({ each: true })
+  @Type(() => CharacterAbilityDTO)
+  ability: CharacterAbilityDTO[];
 }

--- a/src/character/character.service.ts
+++ b/src/character/character.service.ts
@@ -3,13 +3,15 @@ import { NxapiService } from 'src/nxapi/nxapi.service';
 import { characterBasicMapper } from './mapper/character-basic.mapper';
 import { characterStatMapper } from './mapper/character-stat.mapper';
 import { CharacterRepository } from './repository/character.repository';
+import { Character } from './type/character.type';
 import { CharacterBasic } from './type/character-basic.type';
 import { CharacterStat } from './type/character-stat.type';
-import { Character } from './type/character.type';
 import { CharacterHyperStat } from './type/character-hyper-stat.type';
 import { characterHyperStatMapper } from './mapper/character-hyper-stat.mapper';
-import { characterPropensityMapper } from './mapper/character-propensity.mapper';
 import { CharacterPropensity } from './type/character-propensity.type';
+import { characterPropensityMapper } from './mapper/character-propensity.mapper';
+import { CharacterAbility, AbilityData } from './type/character-ability.type';
+import { characterAbilityMapper } from './mapper/character-ability.mapper';
 
 @Injectable()
 export class CharacterService {
@@ -35,12 +37,14 @@ export class CharacterService {
         this.fetchCharacterStat(ocid, date),
         this.fetchCharacterHyperStat(ocid, date),
         this.fetchCharacterPropensity(ocid, date),
+        this.fetchCharacterAbility(ocid, date),
       ];
-      const [basic, stat, hyperStat, propensity] = (await Promise.all(promises)) as [
+      const [basic, stat, hyperStat, propensity, ability] = (await Promise.all(promises)) as [
         CharacterBasic,
         CharacterStat[],
         CharacterHyperStat[],
         CharacterPropensity,
+        CharacterAbility[],
       ];
 
       const updatedCharacter = {
@@ -49,6 +53,7 @@ export class CharacterService {
         stat,
         hyperStat,
         propensity,
+        ability,
       };
 
       // DB보다 과거 데이터를 요청한 경우, DB에 저장하지 않음
@@ -87,5 +92,11 @@ export class CharacterService {
     const propensity = await this.nxapiService.fetchCharacterPropensity(ocid, date);
 
     return characterPropensityMapper(propensity);
+  }
+
+  async fetchCharacterAbility(ocid: string, date?: string): Promise<CharacterAbility[]> {
+    const ability = await this.nxapiService.fetchCharacterAbility(ocid, date);
+
+    return characterAbilityMapper(ability as AbilityData);
   }
 }

--- a/src/character/mapper/character-ability.mapper.ts
+++ b/src/character/mapper/character-ability.mapper.ts
@@ -80,8 +80,8 @@ export const characterAbilityMapper = (abilityData: AbilityData): CharacterAbili
     })
     .flat();
   presetAbilities.push({
-    abilityValue: '남은 명성치',
-    remainFame: abilityData.remain_fame,
+    abilityGrade: '남은 명성치',
+    presetNo: abilityData.remain_fame,
   });
 
   // 프리셋 중 현재 적용중인 어빌리티와 동일한 프리셋을 찾아서 active 속성을 true로 변경

--- a/src/character/mapper/character-ability.mapper.ts
+++ b/src/character/mapper/character-ability.mapper.ts
@@ -1,0 +1,102 @@
+import { AbilityData, AbilityInfo, CharacterAbility } from '../type/character-ability.type';
+/*
+{
+  "date": null,
+  "ability_grade": "레전드리",
+  "ability_info": [
+    {
+      "ability_no": "1",
+      "ability_grade": "레전드리",
+      "ability_value": "버프 스킬의 지속 시간 49% 증가"
+    },
+    {
+      "ability_no": "2",
+      "ability_grade": "유니크",
+      "ability_value": "보스 몬스터 공격 시 데미지 9% 증가"
+    },
+    {
+      "ability_no": "3",
+      "ability_grade": "유니크",
+      "ability_value": "상태 이상에 걸린 대상 공격 시 데미지 8% 증가"
+    }
+  ],
+  "remain_fame": 1372430,
+  "preset_no": 1,
+  "ability_preset_1": {
+    "ability_preset_grade": "레전드리",
+    "ability_info": [
+      {
+        "ability_no": "1",
+        "ability_grade": "레전드리",
+        "ability_value": "버프 스킬의 지속 시간 49% 증가"
+      },
+      {
+        "ability_no": "2",
+        "ability_grade": "유니크",
+        "ability_value": "보스 몬스터 공격 시 데미지 9% 증가"
+      },
+      {
+        "ability_no": "3",
+        "ability_grade": "유니크",
+        "ability_value": "상태 이상에 걸린 대상 공격 시 데미지 8% 증가"
+      }
+    ]
+  },
+  "ability_preset_2": {
+    "ability_preset_grade": "레전드리",
+    "ability_info": [
+      // 프리셋 1과 동일구조
+    ]
+  },
+  "ability_preset_3": {
+    "ability_preset_grade": "에픽",
+    "ability_info": [
+      // 프리셋 1과 동일구조
+    ]
+  }
+}
+*/
+export const characterAbilityMapper = (abilityData: AbilityData): CharacterAbility[] => {
+  const mainAbilities = abilityData.ability_info.map((ability: AbilityInfo) => ({
+    abilityNo: parseInt(ability.ability_no, 10),
+    abilityGrade: ability.ability_grade,
+    abilityValue: ability.ability_value,
+    remainFame: abilityData.remain_fame, // 남은 명성치
+    active: true,
+  }));
+
+  const presetAbilities = [1, 2, 3]
+    .map((presetNumber) => {
+      const presetKey = `ability_preset_${presetNumber}`;
+      const preset = abilityData[presetKey];
+
+      return preset.ability_info.map((ability: AbilityInfo) => ({
+        abilityNo: parseInt(ability.ability_no, 10), // NXAPI에서 ability_no가 string으로 와서 number로 변환...
+        abilityGrade: ability.ability_grade,
+        abilityValue: ability.ability_value,
+        active: false,
+        presetNo: presetNumber,
+      }));
+    })
+    .flat();
+  presetAbilities.push({
+    abilityValue: '남은 명성치',
+    remainFame: abilityData.remain_fame,
+  });
+
+  // 프리셋 중 현재 적용중인 어빌리티와 동일한 프리셋을 찾아서 active 속성을 true로 변경
+  presetAbilities.forEach((ability: CharacterAbility) => {
+    if (
+      mainAbilities.some(
+        (mainAbility) =>
+          mainAbility.abilityNo === ability.abilityNo &&
+          mainAbility.abilityGrade === ability.abilityGrade &&
+          mainAbility.abilityValue === ability.abilityValue,
+      )
+    ) {
+      ability.active = true;
+    }
+  });
+
+  return presetAbilities;
+};

--- a/src/character/repository/character.repository.ts
+++ b/src/character/repository/character.repository.ts
@@ -15,11 +15,13 @@ export class CharacterRepository {
         stat: true,
         hyperStat: true,
         propensity: true,
+        ability: true,
       },
     });
   }
 
   async upsertCharacterOverall(characterData: Character) {
+    console.log(`Upserting character: ${characterData.nickname}`);
     return this.prismaService.character.upsert({
       where: {
         nickname: characterData.nickname,
@@ -37,6 +39,10 @@ export class CharacterRepository {
         propensity: {
           update: characterData.propensity,
         },
+        ability: {
+          deleteMany: {},
+          create: characterData.ability,
+        },
       },
       create: {
         ...characterData,
@@ -48,6 +54,9 @@ export class CharacterRepository {
         },
         propensity: {
           create: characterData.propensity,
+        },
+        ability: {
+          create: characterData.ability,
         },
       },
     });

--- a/src/character/type/character-ability.type.ts
+++ b/src/character/type/character-ability.type.ts
@@ -4,7 +4,6 @@ export interface CharacterAbility {
   abilityGrade: string;
   abilityNo: number;
   abilityValue: string;
-  remainFame?: number;
   presetNo: number;
   active: boolean;
 }

--- a/src/character/type/character-ability.type.ts
+++ b/src/character/type/character-ability.type.ts
@@ -1,0 +1,32 @@
+export interface CharacterAbility {
+  id?: number;
+  characterId?: number;
+  abilityGrade: string;
+  abilityNo: number;
+  abilityValue: string;
+  remainFame: number;
+  presetNo: number;
+  active: boolean;
+}
+
+// 어빌리티의 개별 정보 타입
+export interface AbilityInfo {
+  ability_no: string;
+  ability_grade: string;
+  ability_value: string;
+}
+
+// 프리셋 어빌리티 정보 타입
+export interface PresetAbilityInfo {
+  ability_preset_grade: string;
+  ability_info: AbilityInfo[];
+}
+
+// 전체 어빌리티 데이터 구조
+export interface AbilityData {
+  ability_info: AbilityInfo[];
+  remain_fame: number;
+  ability_preset_1?: PresetAbilityInfo;
+  ability_preset_2?: PresetAbilityInfo;
+  ability_preset_3?: PresetAbilityInfo;
+}

--- a/src/character/type/character-ability.type.ts
+++ b/src/character/type/character-ability.type.ts
@@ -4,7 +4,7 @@ export interface CharacterAbility {
   abilityGrade: string;
   abilityNo: number;
   abilityValue: string;
-  remainFame: number;
+  remainFame?: number;
   presetNo: number;
   active: boolean;
 }

--- a/src/character/type/character.type.ts
+++ b/src/character/type/character.type.ts
@@ -2,9 +2,11 @@ import { CharacterBasic } from './character-basic.type';
 import { CharacterHyperStat } from './character-hyper-stat.type';
 import { CharacterStat } from './character-stat.type';
 import { CharacterPropensity } from './character-propensity.type';
+import { CharacterAbility } from './character-ability.type';
 
 export interface Character extends CharacterBasic {
   stat: CharacterStat[];
   hyperStat: CharacterHyperStat[];
   propensity: CharacterPropensity;
+  ability: CharacterAbility[];
 }


### PR DESCRIPTION
## 어빌리티 기능 구현 내용
- NXAPI에서 오는 내용에 현재 적용중인 어빌리티가 몇 번째 프리셋인지 알려주긴 했음. 하지만 내용은 중복되기 때문에 적용중인 어빌리티 내용은 포함시키지 않고 프리셋에 ```active``` 값으로 표현.
- 남은 명성치 값은 따로 저장