### PR TITLE
🔨 Fix: 특정 캐릭터에서 발생하는 심볼 Rate 관련 오류 수정(RD-60)

### DIFF
--- a/src/nxapi/mapper/symbol.mapper.ts
+++ b/src/nxapi/mapper/symbol.mapper.ts
@@ -11,9 +11,9 @@ const symbolInfoMapper = (symbolData: NxapiSymbolInfo): SymbolDto => {
     int: parseInt(symbolData.symbol_int),
     luk: parseInt(symbolData.symbol_luk),
     hp: parseInt(symbolData.symbol_hp),
-    dropRate: parseInt(symbolData.symbol_drop_rate),
-    mesoRate: parseInt(symbolData.symbol_meso_rate),
-    expRate: parseInt(symbolData.symbol_exp_rate),
+    dropRate: symbolData.symbol_drop_rate ? parseInt(symbolData.symbol_drop_rate) : 0,
+    mesoRate: symbolData.symbol_meso_rate ? parseInt(symbolData.symbol_meso_rate) : 0,
+    expRate: symbolData.symbol_exp_rate ? parseInt(symbolData.symbol_exp_rate) : 0,
     growthCount: symbolData.symbol_growth_count,
     requireGrowthCount: symbolData.symbol_require_growth_count,
   };

--- a/src/nxapi/type/nxapi-symbol.type.ts
+++ b/src/nxapi/type/nxapi-symbol.type.ts
@@ -8,9 +8,9 @@ export interface NxapiSymbolInfo {
   symbol_int: string;
   symbol_luk: string;
   symbol_hp: string;
-  symbol_drop_rate: string;
-  symbol_meso_rate: string;
-  symbol_exp_rate: string;
+  symbol_drop_rate?: string;
+  symbol_meso_rate?: string;
+  symbol_exp_rate?: string;
   symbol_growth_count: number;
   symbol_require_growth_count: number;
 }


### PR DESCRIPTION
## 심볼 Rate값 NaN 오류 처리
- 특정 캐릭터에서 레이트 관련 항목에 대한 값이 null로 반환되어 API 자체가 터져버리는 오류 해결.
- nxapi에서 null로 오는 경우 0으로 저장하도록 함
- 다른 캐릭터들은 "0%"로 오는데, 스펙이 낮은 특정 캐릭터들은 null로 오는 이유는 아직 잘 모르겠음. 근데 스펙이 꼭 낮다고 발생하는 건 아닌 것 같기도 하고..